### PR TITLE
Add book CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build Book
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build book
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Cloning repository
+
+      - uses: actions/checkout@v3
+        name: Cloning Look
+        with:
+          repository: "juxt/look"
+          path: "look"
+          ref: "master"
+          token: ${{ secrets.ACCESS_TOKEN }}
+          sparse-checkout: |
+            stationery
+
+      - name: Install clojure
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: "1.11.1.1403"
+          bb: "latest"
+
+      - name: Install apt dependencies
+        run: |
+          mkdir -p ~/src/github.com/juxt
+          mv look ~/src/github.com/juxt/look
+          sudo apt install -y ruby-dev cmake bison flex g++ pkg-config libglib2.0-dev libcairo2-dev libpango1.0-dev libgdk-pixbuf-2.0-dev libxml2-dev libwebp-dev libzstd-dev openjdk-11-jre
+
+      - uses: ruby/setup-ruby@v1
+        name: Install Ruby
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+
+      - uses: reitzig/actions-asciidoctor@v2.0.1
+        name: Install Asciidoctor
+        with:
+          version: 2.0.18
+
+      - name: Build book
+        run: make
+
+      - uses: marvinpinto/action-automatic-releases@latest
+        name: Publish release
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          title: "Latest edition of the book"
+          files: |
+            Site.pdf

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem 'asciidoctor'
 gem 'mathematical'
+gem 'asciidoctor-pdf'
 gem 'asciidoctor-diagram-plantuml'
 gem 'asciidoctor-diagram'
 gem 'asciidoctor-bibtex'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.1.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    afm (0.2.2)
     asciidoctor (2.0.20)
     asciidoctor-bibtex (0.8.0)
       asciidoctor (~> 2.0)
@@ -19,6 +23,16 @@ GEM
       asciidoctor (~> 2.0)
       asciimath (~> 2.0)
       mathematical (~> 1.6.0)
+    asciidoctor-pdf (2.3.9)
+      asciidoctor (~> 2.0)
+      concurrent-ruby (~> 1.1)
+      matrix (~> 0.4)
+      prawn (~> 2.4.0)
+      prawn-icon (~> 3.0.0)
+      prawn-svg (~> 0.32.0)
+      prawn-table (~> 0.2.0)
+      prawn-templates (~> 0.1.0)
+      treetop (~> 1.6.0)
     asciimath (2.0.5)
     bibtex-ruby (5.1.6)
       latex-decode (~> 0.0)
@@ -33,15 +47,46 @@ GEM
       rexml
     csl-styles (1.0.1.11)
       csl (~> 1.0)
+    css_parser (1.16.0)
+      addressable
+    hashery (2.1.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     latex-decode (0.4.0)
     mathematical (1.6.14)
       ruby-enum (~> 0.4)
+    matrix (0.4.2)
     namae (1.1.1)
+    pdf-core (0.9.0)
+    pdf-reader (2.11.0)
+      Ascii85 (~> 1.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
+    polyglot (0.3.5)
+    prawn (2.4.0)
+      pdf-core (~> 0.9.0)
+      ttfunk (~> 1.7)
+    prawn-icon (3.0.0)
+      prawn (>= 1.1.0, < 3.0.0)
+    prawn-svg (0.32.0)
+      css_parser (~> 1.6)
+      prawn (>= 0.11.1, < 3)
+      rexml (~> 3.2)
+    prawn-table (0.2.2)
+      prawn (>= 1.3.0, < 3.0.0)
+    prawn-templates (0.1.2)
+      pdf-reader (~> 2.0)
+      prawn (~> 2.2)
+    public_suffix (5.0.3)
     rexml (3.2.5)
     ruby-enum (0.9.0)
       i18n
+    ruby-rc4 (0.1.5)
+    treetop (1.6.12)
+      polyglot (~> 0.3)
+    ttfunk (1.7.0)
 
 PLATFORMS
   x86_64-linux
@@ -52,6 +97,7 @@ DEPENDENCIES
   asciidoctor-diagram
   asciidoctor-diagram-plantuml
   asciidoctor-mathematical
+  asciidoctor-pdf
   mathematical
 
 BUNDLED WITH

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ fonts:
 	bb -o edn2json $< > $@
 
 %.pdf:	%.adoc
-	asciidoctor-pdf \
+	bundle exec asciidoctor-pdf \
 	-a toc=macro \
 	-r asciidoctor-diagram \
 	-r asciidoctor-mathematical \


### PR DESCRIPTION
Adds a CI pipeline to build a new version of the book for every commit. The date inside seems to be hard-coded, so that should probably be updated too.

Since this depends on a private repo in another org, a token is also needed to be added as a repository secret

The release looks like [this](https://github.com/elken/book/releases/tag/latest), should agree on things like whether to mark it as pre-release, what title to use, etc